### PR TITLE
Delete duplicate Properties key

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -317,7 +317,6 @@ Resources:
   CapstoneConnectIntegration:
     Type: AWS::ApiGatewayV2::Integration
     Properties:
-    Properties:
       ApiId: !Ref CapstoneWebSocketApi
       IntegrationType: AWS_PROXY
       CredentialsArn: !GetAtt ConnectRouteApiRole.Arn


### PR DESCRIPTION
There is a duplicated `Properties` key, which when loading this template in Application Composer, causes users to get an error